### PR TITLE
Remove println from KotlinContext

### DIFF
--- a/src/main/kotlin/com/github/rahulsom/svg/KotlinContext.kt
+++ b/src/main/kotlin/com/github/rahulsom/svg/KotlinContext.kt
@@ -16,7 +16,6 @@ class KotlinContext {
         things.add(it.invoke(ObjectFactory(), thing) as JAXBElement<*>)
 
     private fun getMethod(thing: Any): Method? {
-        println("Expecting: ${thing::class.java}")
         return ObjectFactory::class.java.declaredMethods
             .filter {
                 it.returnType == JAXBElement::class.java &&


### PR DESCRIPTION
I hope PRs are OK!

`getMethod` is used pretty heavily during generation and the `println` within it causes a lot of unnecessary logging.