### PR TITLE
chore: Update config names in build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ dependencies {
 
   compileOnly 'org.codehaus.groovy:groovy-all:3.0.3'
 
-  testCompile 'org.spockframework:spock-core:1.3-groovy-2.5'
-  testCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
+  testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
+  testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
   compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71"
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,5 +5,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.thaiopensource:trang:20091111'
+    implementation 'com.thaiopensource:trang:20091111'
 }


### PR DESCRIPTION
`compile` and `testCompile` are deprecated in favor of `implementation` and `testImplementation`.