### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Gradle Build
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/rahulsom/svg-builder/security/code-scanning/1](https://github.com/rahulsom/svg-builder/security/code-scanning/1)

To fix the problem, add an explicit `permissions:` block to the workflow. This should be placed at the top level for the whole workflow (which applies to all jobs whose permissions aren't set at the job level), or within the specific job if different jobs need different permissions. Since this workflow has only one job (`build`), you could add `permissions:` at either the root or job level. However, adding it at the root is the clearest approach unless you want to be very specific.

Best practice is to use the principle of least privilege: start with `contents: read`, and add further write permissions only if required (e.g., if the scripts, jobs, or reusable workflow need to create issues or pull requests). If you're unsure, use only `contents: read` as a minimal starting point.

**Region to change:**  
- File: `.github/workflows/build.yml`
- Place the following block before or after `on:` (preferably after the workflow name).
- No imports or other definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
